### PR TITLE
fix: correct package path in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["铂屑 <80164656+boxie123@users.noreply.github.com>"]
 readme = "README.md"
-packages = [{include = "bilibili_getreceivedgiftstream"}]
+packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "~3.11.4"


### PR DESCRIPTION
修改 pyproject.toml 中的 packages 配置。将错误的路径`bilibili_getreceivedgiftstream` 更正为 `src`，以匹配实际的项目目录结构。
- 更新 packages 配置为 [{include = "src"}]
- 确保 Poetry/PDM 能正确识别并安装项目包